### PR TITLE
最新のバージョンのPythonでSSLエラーになる問題を修正

### DIFF
--- a/b2cloud/__init__.py
+++ b/b2cloud/__init__.py
@@ -6,6 +6,8 @@ import zlib
 import lxml.html
 import requests
 
+from b2cloud.adapters import HTTPSAdapter
+
 # データキャッシュ用
 CACHE = {}
 
@@ -23,6 +25,7 @@ def login(customer_code:str, customer_password:str, customer_cls_cocde='', login
     '''
 
     session = requests.Session()
+    session.mount("https://", HTTPSAdapter())
     data = {
         'quickLoginCheckH': '',
         'BTN_NM': 'LOGIN',

--- a/b2cloud/adapters.py
+++ b/b2cloud/adapters.py
@@ -1,0 +1,15 @@
+import ssl
+import urllib3
+from urllib3.util import ssl_
+from requests.adapters import HTTPAdapter
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class HTTPSAdapter(HTTPAdapter):
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["ssl_context"] = ssl_.create_urllib3_context(
+            ciphers="AES256-SHA", cert_reqs=ssl.CERT_OPTIONAL, options=0
+        )
+        return super().init_poolmanager(*args, **kwargs)

--- a/b2cloud/adapters.py
+++ b/b2cloud/adapters.py
@@ -1,15 +1,20 @@
 import ssl
 import urllib3
-from urllib3.util import ssl_
+from urllib3.util import create_urllib3_context
 from requests.adapters import HTTPAdapter
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+ctx = create_urllib3_context()
+ctx.load_default_certs()
+ctx.set_ciphers("DEFAULT:@SECLEVEL=0")
+ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+
 
 class HTTPSAdapter(HTTPAdapter):
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ctx
+        super().__init__(**kwargs)
 
-    def init_poolmanager(self, *args, **kwargs):
-        kwargs["ssl_context"] = ssl_.create_urllib3_context(
-            ciphers="AES256-SHA", cert_reqs=ssl.CERT_OPTIONAL, options=0
-        )
-        return super().init_poolmanager(*args, **kwargs)
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = urllib3.poolmanager.PoolManager(num_pools=connections, maxsize=maxsize, block=block, ssl_context=self.ssl_context)


### PR DESCRIPTION
ヤマト運輸のHTTTPSサーバにおいて非推奨となったSSLv3が有効になっているため、直近のバージョンではエラーになってしまていた。

```
ssl.SSLError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] ssl/tls alert handshake failure (_ssl.c:1006)
```

暗号化アルゴリズムを明示することで対応。