### PR TITLE
例外のリファクタリング

### DIFF
--- a/b2cloud/exceptions.py
+++ b/b2cloud/exceptions.py
@@ -1,0 +1,6 @@
+class B2CloudError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+class LoginError(B2CloudError):
+    pass


### PR DESCRIPTION
* HTTPのリクエストの応答ステータスを逐一 `response.raise_for_status()` で確認
  * 確認しない場合、その後のJSONへのアクセスでKeyError等が発生するが、意味がわからなくなってしまうため先にチェックする
* ログイン時のリトライを廃止し、HTTPのエラーの場合は`response.raise_for_status()` にてオリジナルの例外を発行
* 本ライブラリの基本となる例外クラス `B2CloudError` を定義して利用
* 未実装の例外は `NotImplemented` を利用
* HTTPのレスポンスの変数名を `response` で統一
 